### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,6 +6,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
     gh-pages-deploy:
       name: Deploying to gh-pages


### PR DESCRIPTION
Potential fix for [https://github.com/d3ward/kiwihub/security/code-scanning/1](https://github.com/d3ward/kiwihub/security/code-scanning/1)

To fix the problem, explicitly declare the minimal `permissions` required for this workflow instead of relying on repository defaults. Since `peaceiris/actions-gh-pages@v3` pushes built assets to the `gh-pages` branch using `GITHUB_TOKEN`, the job needs `contents: write` and does not appear to require any other scopes.

The best fix without changing functionality is to add a `permissions` block at the workflow root (top level, alongside `name:` and `on:`) that applies to all jobs. Concretely, in `.github/workflows/deploy.yml`, insert:

```yaml
permissions:
  contents: write
```

between the `on:` block and the `jobs:` block. This keeps the deployment working (it can still push to `gh-pages`) while preventing accidental broader default scopes like write access to issues or pull requests. No imports or additional methods are needed since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
